### PR TITLE
Add pointer to RCC_TypeDef as first function parameter in RCC HAL API

### DIFF
--- a/hal/hal_rcc.h
+++ b/hal/hal_rcc.h
@@ -15,15 +15,15 @@
 
 #define HAL_RCC_PERIPH_BASEADDR_OFFSET  0x0400
 
-__STATIC_INLINE void hal_rcc_enable(hal_rcc_periph_t periph_msk);
+__STATIC_INLINE void hal_rcc_enable(RCC_TypeDef * p_rcc, hal_rcc_periph_t periph_msk);
 
-__STATIC_INLINE void hal_rcc_apb_periph_enable(volatile uint32_t * p_periph);
+__STATIC_INLINE void hal_rcc_apb_periph_enable(RCC_TypeDef * p_rcc, void * p_periph);
 
-__STATIC_INLINE uint32_t hal_rcc_apb_clock_get(void);
+__STATIC_INLINE uint32_t hal_rcc_apb_clock_get(RCC_TypeDef * p_rcc);
 
 #ifndef __MOCK_HAL
 
-__STATIC_INLINE void hal_rcc_enable(hal_rcc_periph_t periph_msk)
+__STATIC_INLINE void hal_rcc_enable(RCC_TypeDef * p_rcc, hal_rcc_periph_t periph_msk)
 {
     uint32_t bus_msk     = periph_msk >> HAL_RCC_BUS_BITPOS;
     uint32_t rcc_bit_msk = 1 << (periph_msk &  HAL_RCC_PERIPH_BITPOS_MSK);
@@ -53,7 +53,7 @@ __STATIC_INLINE void hal_rcc_enable(hal_rcc_periph_t periph_msk)
     *rcc_reg |= rcc_bit_msk;
 }
 
-__STATIC_INLINE void hal_rcc_apb_periph_enable(volatile uint32_t * p_periph)
+__STATIC_INLINE void hal_rcc_apb_periph_enable(RCC_TypeDef * p_rcc, void * p_periph)
 {
     uint32_t bus_index = ((uint32_t)p_periph & HAL_RCC_BUS_APB_INDEX_MSK);
     uint32_t rcc_bit_pos = ((uint32_t)p_periph & HAL_RCC_PERIPH_BASEADDR_MSK) /
@@ -66,8 +66,9 @@ __STATIC_INLINE void hal_rcc_apb_periph_enable(volatile uint32_t * p_periph)
     }
 }
 
-__STATIC_INLINE uint32_t hal_rcc_apb_clock_get(void)
+__STATIC_INLINE uint32_t hal_rcc_apb_clock_get(RCC_TypeDef * p_rcc)
 {
+    (void)p_rcc;
 #if defined(STM32_SERIES_F0)
     return 8000000;
 #else

--- a/hal/hal_tim.h
+++ b/hal/hal_tim.h
@@ -116,7 +116,7 @@ __STATIC_INLINE void hal_tim_timer_cfg(TIM_TypeDef * p_tim,
                                        uint32_t      freq_hz,
                                        uint32_t      period_ticks)
 {
-    uint32_t apb_clock = hal_rcc_apb_clock_get();
+    uint32_t apb_clock = hal_rcc_apb_clock_get(RCC);
     p_tim->PSC = (apb_clock / freq_hz) - 1;
     p_tim->ARR = period_ticks - 1;
 }

--- a/hal/hal_usart.h
+++ b/hal/hal_usart.h
@@ -138,7 +138,7 @@ __STATIC_INLINE void hal_usart_byte_tx(USART_TypeDef * p_usart, uint8_t byte);
 
 __STATIC_INLINE void hal_usart_init(USART_TypeDef * p_usart)
 {
-    hal_rcc_apb_periph_enable((volatile uint32_t *)p_usart);
+    hal_rcc_apb_periph_enable(RCC, p_usart);
 }
 
 __STATIC_INLINE void hal_usart_uninit(USART_TypeDef * p_usart)
@@ -148,7 +148,7 @@ __STATIC_INLINE void hal_usart_uninit(USART_TypeDef * p_usart)
 
 __STATIC_INLINE void hal_usart_baudrate_set(USART_TypeDef * p_usart, hal_usart_baud_t baud)
 {
-    p_usart->BRR = hal_rcc_apb_clock_get() / (uint32_t)baud;
+    p_usart->BRR = hal_rcc_apb_clock_get(RCC) / (uint32_t)baud;
 }
 
 __STATIC_INLINE void hal_usart_parity_set(USART_TypeDef * p_usart, hal_usart_parity_t parity)
@@ -201,7 +201,7 @@ __STATIC_INLINE void hal_usart_cfg(USART_TypeDef *     p_usart,
                                   hal_usart_stopbits_t stopbits,
                                   hal_usart_parity_t   parity)
 {
-    p_usart->BRR = hal_rcc_apb_clock_get() / baud;
+    p_usart->BRR = hal_rcc_apb_clock_get(RCC) / baud;
 
     p_usart->CR2 = (uint32_t)stopbits;
 


### PR DESCRIPTION
Resolves #42.